### PR TITLE
Allow the tag Volume to continue to the next volume if the volume is not found.

### DIFF
--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -63,7 +63,11 @@ class GraffitiMonkey(object):
             if volume.status != 'in-use':
                 log.debug('Skipping %s as it is not attached to an EC2 instance, so there is nothing to propagate', volume.id)
                 continue
-            self.tag_volume(volume)
+            try:
+                self.tag_volume(volume)
+            except boto.exception.EC2ResponseError, e:
+                print "Encountered Error %s on volume %s" % (e.error_code, volume.id)
+                continue
 
 
     def tag_volume(self, volume):


### PR DESCRIPTION
While running the program, it would occasionally hit a volume that it can no longer find. This is probably due to the fact the the volume was deleted between the time it was found in the list and when the program got around to tagging it. When it didn't find the volume, the program would print the error message and terminate.

This should allow the program to continue on even when the volume isn't found.
