### PR TITLE
Print statement shouldn't be used when all other string output is via a logger

### DIFF
--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -66,7 +66,7 @@ class GraffitiMonkey(object):
             try:
                 self.tag_volume(volume)
             except boto.exception.EC2ResponseError, e:
-                print "Encountered Error %s on volume %s" % (e.error_code, volume.id)
+                log.error("Encountered Error %s on volume %s", e.error_code, volume.id)
                 continue
 
 


### PR DESCRIPTION
Hi,

This is just a minor change but I noticed that the output was not consistent so I thought it would be nicer to use the logger for this one.

Kind regards,

Peter
