### PR TITLE
Added --append option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,11 +18,11 @@ Usage
 
 ::
 
-	usage: graffiti-monkey [-h] [--region REGION] [--verbose] [--version] [--config CONFIG.YML]
-	
+	usage: graffiti-monkey [-h] [--region REGION] [--verbose] [--version] [--config CONFIG.YML] [--dryrun]
+
 	Propagates tags from AWS EC2 instances to EBS volumes, and then to EBS
 	snapshots. This makes it much easier to find things down the road.
-	
+
 	optional arguments:
 	  -h, --help           show this help message and exit
 	  --region REGION      the region to tag things in (default is current region of
@@ -30,6 +30,7 @@ Usage
 	  --verbose, -v        enable verbose output (-vvv for more)
 	  --version            display version number and exit
 	  --config CONFIG.YML  read a yaml configuration file.  specify tags to propagate without changing code.
+    --dryrun             dryrun only, display tagging actions but do not perform them
 
 Examples
 --------
@@ -41,10 +42,10 @@ Suppose you have the following in `us-east-1`:
 	i-abcd1234
 	  - Tags:
 	    - Name: "Instance 1"
-	 
+
 	vol-bcde3456
 	  - Attached to i-abcd1234 on /dev/sda1
-	 
+
 	snap-cdef4567
 	  - Snapshot of vol-bcde3456
 
@@ -65,7 +66,7 @@ First, Graffiti Monkey will set the EBS volume tags
 	    - Name: "Instance 1"
 	    - instance_id: i-abcd1234
 	    - device: /dev/sda1
-	    
+
 and then it will set the tags on the EBS Snapshot
 
 ::
@@ -86,7 +87,7 @@ You can install Graffiti Monkey using the usual PyPI channels. Example:
 ::
 
     sudo pip install graffiti_monkey
-    
+
 You can find the package details here: https://pypi.python.org/pypi/graffiti_monkey
 
 Alternatively, if you prefer to install from source:

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ Usage
 	  --verbose, -v        enable verbose output (-vvv for more)
 	  --version            display version number and exit
 	  --config CONFIG.YML  read a yaml configuration file.  specify tags to propagate without changing code.
-    --dryrun             dryrun only, display tagging actions but do not perform them
-    --append             append propagated tags to existing tags (up to a total of ten tags). When not set,
-                         graffiti-monkey will overwrite existing tags.
+	  --dryrun             dryrun only, display tagging actions but do not perform them
+	  --append             append propagated tags to existing tags (up to a total of ten tags). When not set,
+	                       graffiti-monkey will overwrite existing tags.
 
 Examples
 --------

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ Usage
 	  --version            display version number and exit
 	  --config CONFIG.YML  read a yaml configuration file.  specify tags to propagate without changing code.
     --dryrun             dryrun only, display tagging actions but do not perform them
+    --append             append propagated tags to existing tags (up to a total of ten tags). When not set,
+                         graffiti-monkey will overwrite existing tags.
 
 Examples
 --------

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -59,9 +59,9 @@ class GraffitiMonkeyCli(object):
                             help='display version number and exit')
         parser.add_argument('--config', '-c', nargs="?", type=argparse.FileType('r'),
                         default=None, help="Give a yaml configuration file")
-        parser.add_argument('--dryrun', action='store_false',
+        parser.add_argument('--dryrun', action='store_true',
                             help='dryrun only, display tagging actions but do not perform them')
-        parser.add_argument('--append', action='store_false',
+        parser.add_argument('--append', action='store_true',
                             help='append propagated tags to existing tags (up to a total of ten tags)')
         self.args = parser.parse_args(self.get_argv())
 

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -35,6 +35,7 @@ class GraffitiMonkeyCli(object):
         self.config = {"_instance_tags_to_propagate": ['Name'],
                        "_volume_tags_to_propagate": ['Name', 'instance_id', 'device']}
         self.dryrun = False
+        self.append = False
 
     @staticmethod
     def _fail(message="Unknown failure", code=1):
@@ -60,6 +61,8 @@ class GraffitiMonkeyCli(object):
                         default=None, help="Give a yaml configuration file")
         parser.add_argument('--dryrun', action='store_true',
                             help='dryrun only, display tagging actions but do not perform them')
+        parser.add_argument('--append', action='store_true',
+                            help='append propagated tags to existing tags (up to a total of ten tags)')
         self.args = parser.parse_args(self.get_argv())
 
     @staticmethod
@@ -107,11 +110,15 @@ class GraffitiMonkeyCli(object):
     def set_dryrun(self):
         self.dryrun = self.args.dryrun
 
+    def set_append(self):
+        self.append = self.args.append
+
     def initialize_monkey(self):
         self.monkey = GraffitiMonkey(self.region,
                                      self.config["_instance_tags_to_propagate"],
                                      self.config["_volume_tags_to_propagate"],
-                                     self.dryrun)
+                                     self.dryrun,
+                                     self.append)
 
 
     def start_tags_propagation(self):
@@ -130,6 +137,7 @@ class GraffitiMonkeyCli(object):
         self.set_config()
         self.set_region()
         self.set_dryrun()
+        self.set_append()
 
         try:
             self.initialize_monkey()

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -59,7 +59,7 @@ class GraffitiMonkeyCli(object):
                             help='display version number and exit')
         parser.add_argument('--config', '-c', nargs="?", type=argparse.FileType('r'),
                         default=None, help="Give a yaml configuration file")
-        parser.add_argument('--dryrun', action='store_true',
+        parser.add_argument('--dryrun', action='store_false',
                             help='dryrun only, display tagging actions but do not perform them')
         parser.add_argument('--append', action='store_false',
                             help='append propagated tags to existing tags (up to a total of ten tags)')

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -34,6 +34,7 @@ class GraffitiMonkeyCli(object):
         self.args = None
         self.config = {"_instance_tags_to_propagate": ['Name'],
                        "_volume_tags_to_propagate": ['Name', 'instance_id', 'device']}
+        self.dryrun = False
 
     @staticmethod
     def _fail(message="Unknown failure", code=1):
@@ -57,6 +58,8 @@ class GraffitiMonkeyCli(object):
                             help='display version number and exit')
         parser.add_argument('--config', '-c', nargs="?", type=argparse.FileType('r'),
                         default=None, help="Give a yaml configuration file")
+        parser.add_argument('--dryrun', action='store_true',
+                            help='dryrun only, display tagging actions but do not perform them')
         self.args = parser.parse_args(self.get_argv())
 
     @staticmethod
@@ -101,10 +104,14 @@ class GraffitiMonkeyCli(object):
             self.region = instance_metadata['placement']['availability-zone'][:-1]
             log.debug("Running in region: %s", self.region)
 
+    def set_dryrun(self):
+        self.dryrun = self.args.dryrun
+
     def initialize_monkey(self):
         self.monkey = GraffitiMonkey(self.region,
                                      self.config["_instance_tags_to_propagate"],
-                                     self.config["_volume_tags_to_propagate"])
+                                     self.config["_volume_tags_to_propagate"],
+                                     self.dryrun)
 
 
     def start_tags_propagation(self):
@@ -122,6 +129,7 @@ class GraffitiMonkeyCli(object):
 
         self.set_config()
         self.set_region()
+        self.set_dryrun()
 
         try:
             self.initialize_monkey()

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -61,7 +61,7 @@ class GraffitiMonkeyCli(object):
                         default=None, help="Give a yaml configuration file")
         parser.add_argument('--dryrun', action='store_true',
                             help='dryrun only, display tagging actions but do not perform them')
-        parser.add_argument('--append', action='store_true',
+        parser.add_argument('--append', action='store_false',
                             help='append propagated tags to existing tags (up to a total of ten tags)')
         self.args = parser.parse_args(self.get_argv())
 

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -61,7 +61,7 @@ class GraffitiMonkeyCli(object):
                         default=None, help="Give a yaml configuration file")
         parser.add_argument('--dryrun', action='store_true',
                             help='dryrun only, display tagging actions but do not perform them')
-        parser.add_argument('--append', action='store_false',
+        parser.add_argument('--append', action='store_true',
                             help='append propagated tags to existing tags (up to a total of ten tags)')
         self.args = parser.parse_args(self.get_argv())
 

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -59,7 +59,7 @@ class GraffitiMonkeyCli(object):
                             help='display version number and exit')
         parser.add_argument('--config', '-c', nargs="?", type=argparse.FileType('r'),
                         default=None, help="Give a yaml configuration file")
-        parser.add_argument('--dryrun', action='store_false',
+        parser.add_argument('--dryrun', action='store_true',
                             help='dryrun only, display tagging actions but do not perform them')
         parser.add_argument('--append', action='store_false',
                             help='append propagated tags to existing tags (up to a total of ten tags)')

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -59,9 +59,9 @@ class GraffitiMonkeyCli(object):
                             help='display version number and exit')
         parser.add_argument('--config', '-c', nargs="?", type=argparse.FileType('r'),
                         default=None, help="Give a yaml configuration file")
-        parser.add_argument('--dryrun', action='store_true',
+        parser.add_argument('--dryrun', action='store_false',
                             help='dryrun only, display tagging actions but do not perform them')
-        parser.add_argument('--append', action='store_true',
+        parser.add_argument('--append', action='store_false',
                             help='append propagated tags to existing tags (up to a total of ten tags)')
         self.args = parser.parse_args(self.get_argv())
 

--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -78,6 +78,9 @@ class GraffitiMonkey(object):
             except boto.exception.EC2ResponseError, e:
                 log.error("Encountered Error %s on volume %s", e.error_code, volume.id)
                 continue
+            except boto.exception.BotoServerError, e:
+                log.error("Encountered Error %s on volume %s", e.error_code, volume.id)
+                continue
         log.info('Completed processing all volumes')
 
 
@@ -128,6 +131,9 @@ class GraffitiMonkey(object):
             try:
                 self.tag_snapshot(snapshot)
             except boto.exception.EC2ResponseError, e:
+                log.error("Encountered Error %s on snapshot %s", e.error_code, snapshot.id)
+                continue
+            except boto.exception.BotoServerError, e:
                 log.error("Encountered Error %s on snapshot %s", e.error_code, snapshot.id)
                 continue
         log.info('Completed processing all snapshots')

--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -64,8 +64,12 @@ class GraffitiMonkey(object):
 
         log.info('Getting list of all volumes')
         volumes = self._conn.get_all_volumes()
-        log.info('Found %d volumes', len(volumes))
+        total_vols = len(volumes)
+        log.info('Found %d volumes', total_vols)
+        this_vol = 0
         for volume in volumes:
+            this_vol +=1
+            log.info ('Processing volume %d of %d total volumes', this_vol, total_vols)
             if volume.status != 'in-use':
                 log.debug('Skipping %s as it is not attached to an EC2 instance, so there is nothing to propagate', volume.id)
                 continue
@@ -74,6 +78,7 @@ class GraffitiMonkey(object):
             except boto.exception.EC2ResponseError, e:
                 log.error("Encountered Error %s on volume %s", e.error_code, volume.id)
                 continue
+        log.info('Completed processing all volumes')
 
 
     def tag_volume(self, volume):
@@ -114,14 +119,18 @@ class GraffitiMonkey(object):
 
         log.info('Getting list of all snapshots')
         snapshots = self._conn.get_all_snapshots(owner='self')
-        log.info('Found %d snapshots', len(snapshots))
+        total_snaps = len(snapshots)
+        log.info('Found %d snapshots', total_snaps)
+        this_snap = 0
         for snapshot in snapshots:
+            this_snap +=1
+            log.info ('Processing snapshot %d of %d total snapshots', this_snap, total_snaps)
             try:
                 self.tag_snapshot(snapshot)
             except boto.exception.EC2ResponseError, e:
                 log.error("Encountered Error %s on snapshot %s", e.error_code, snapshot.id)
                 continue
-
+        log.info('Completed processing all snapshots')
 
     def tag_snapshot(self, snapshot):
         ''' Tags a specific snapshot '''

--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -18,44 +18,47 @@ from cache import Memorize
 from exceptions import *
 
 import boto
-from boto import ec2 
+from boto import ec2
 
 __all__ = ('GraffitiMonkey', 'Logging')
 log = logging.getLogger(__name__)
 
 
 class GraffitiMonkey(object):
-    def __init__(self, region, instance_tags_to_propagate, volume_tags_to_propagate):
-        # This list of tags associated with an EC2 instance to propagate to 
+    def __init__(self, region, instance_tags_to_propagate, volume_tags_to_propagate, dryrun):
+        # This list of tags associated with an EC2 instance to propagate to
         # attached EBS volumes
         self._instance_tags_to_propagate = instance_tags_to_propagate
-        
+
         # This is a list of tags associated with a volume to propagate to
-        # a snapshot created from the volume 
+        # a snapshot created from the volume
         self._volume_tags_to_propagate = volume_tags_to_propagate
-        
+
         # The region to operate in
         self._region = region
-        
+
+        # dryrun
+        self._dryrun = dryrun
+
         log.info("Connecting to region %s", self._region)
         try:
             self._conn = ec2.connect_to_region(self._region)
         except boto.exception.NoAuthHandlerFound:
             raise GraffitiMonkeyException('No AWS credentials found - check your credentials')
 
-    
+
     def propagate_tags(self):
         ''' Propagates tags by copying them from EC2 instance to EBS volume, and
         then to snapshot '''
-        
+
         self.tag_volumes()
         self.tag_snapshots()
-            
+
 
     def tag_volumes(self):
         ''' Gets a list of all volumes, and then loops through them tagging
         them '''
-        
+
         log.info('Getting list of all volumes')
         volumes = self._conn.get_all_volumes()
         log.info('Found %d volumes', len(volumes))
@@ -72,16 +75,16 @@ class GraffitiMonkey(object):
 
     def tag_volume(self, volume):
         ''' Tags a specific volume '''
-                
+
         instance_id = None
         if volume.attach_data.instance_id:
             instance_id = volume.attach_data.instance_id
         device = None
         if volume.attach_data.device:
             device = volume.attach_data.device
-        
+
         instance_tags = self._get_resource_tags(instance_id)
-        
+
         tags_to_set = {}
         for tag_name in self._instance_tags_to_propagate:
             log.debug('Trying to propagate instance tag: %s', tag_name)
@@ -93,31 +96,34 @@ class GraffitiMonkey(object):
         tags_to_set['instance_id'] = instance_id
         tags_to_set['device'] = device
 
-        self._set_resource_tags(volume, tags_to_set)        
+        if self._dryrun:
+            log.info('DRYRUN: Volume %s would have been tagged %s', volume.id, tags_to_set)
+        else:
+            self._set_resource_tags(volume, tags_to_set)
         return True
-    
-    
+
+
     def tag_snapshots(self):
         ''' Gets a list of all snapshots, and then loops through them tagging
         them '''
-        
+
         log.info('Getting list of all snapshots')
         snapshots = self._conn.get_all_snapshots(owner='self')
         log.info('Found %d snapshots', len(snapshots))
         for snapshot in snapshots:
-            self.tag_snapshot(snapshot)    
+            self.tag_snapshot(snapshot)
 
 
     def tag_snapshot(self, snapshot):
         ''' Tags a specific snapshot '''
-                
+
         volume_id = snapshot.volume_id
 #        if volume_id == '':
 #            log.debug('Skipping %s as it does not have volume information', snapshot.id)
 #            continue
-        
+
         volume_tags = self._get_resource_tags(volume_id)
-        
+
         tags_to_set = {}
         for tag_name in self._volume_tags_to_propagate:
             log.debug('Trying to propagate volume tag: %s', tag_name)
@@ -126,15 +132,18 @@ class GraffitiMonkey(object):
                 tags_to_set[tag_name] = value
 
 
-        self._set_resource_tags(snapshot, tags_to_set)        
+        if self._dryrun:
+            log.info('DRYRUN: Snapshot %s would have been tagged %s', snapshot, tags_to_set)
+        else:
+            self._set_resource_tags(snapshot, tags_to_set)
         return True
-        
+
 
     @Memorize
     def _get_resource_tags(self, resource_id):
         ''' Gets all of the tags associated with an AWS resource (such as an
         instance-id, volume-id, etc) as a dictionary '''
-        
+
         resource_tags = {}
         if resource_id:
             # Get the set of tags for a volume
@@ -143,16 +152,16 @@ class GraffitiMonkey(object):
             for tag in tags:
                 resource_tags[tag.name] = tag.value
 
-        return resource_tags    
+        return resource_tags
 
 
     def _set_resource_tags(self, resource, tags):
         ''' Sets the tags on the given AWS resource '''
-        
+
         if not isinstance(resource, ec2.ec2object.TaggedEC2Object):
             msg = 'Resource %s is not an instance of TaggedEC2Object' % resource
             raise GraffitiMonkeyException(msg)
-        
+
         for tag_key, tag_value in tags.iteritems():
             if not tag_key in resource.tags or resource.tags[tag_key] != tag_value:
                 log.info('Tagging %s with [%s: %s]', resource.id, tag_key, tag_value)
@@ -164,10 +173,10 @@ class Logging(object):
     # Logging formats
     _log_simple_format = '%(asctime)s [%(levelname)s] %(message)s'
     _log_detailed_format = '%(asctime)s [%(levelname)s] [%(name)s(%(lineno)s):%(funcName)s] %(message)s'
-    
+
     def configure(self, verbosity = None):
         ''' Configure the logging format and verbosity '''
-        
+
         # Configure our logging output
         if verbosity >= 2:
             logging.basicConfig(level=logging.DEBUG, format=self._log_detailed_format, datefmt='%F %T')
@@ -175,12 +184,11 @@ class Logging(object):
             logging.basicConfig(level=logging.INFO, format=self._log_detailed_format, datefmt='%F %T')
         else:
             logging.basicConfig(level=logging.INFO, format=self._log_simple_format, datefmt='%F %T')
-    
+
         # Configure Boto's logging output
         if verbosity >= 4:
             logging.getLogger('boto').setLevel(logging.DEBUG)
         elif verbosity >= 3:
             logging.getLogger('boto').setLevel(logging.INFO)
         else:
-            logging.getLogger('boto').setLevel(logging.CRITICAL)    
-    
+            logging.getLogger('boto').setLevel(logging.CRITICAL)


### PR DESCRIPTION
By default graffiti-monkey overwrites existing tags when propagating.
Setting this option makes it append the new tags to the list of
existing tags. Note that AWS enforces a maximum of ten tags per
resource and if this limit is exceeded only the first ten tags (with
existing tags taking priority) are set. The tag snapshot function is
wrapped in a try.. except block to handle this.