### PR TITLE
Add support for default tags for volumes and snapshots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,14 @@ Graffiti-monkey itself can be configured using a yaml file
     - 'device'
     - 'Owner'
 
+  _volume_tags_to_be_set:
+    -  key:   'NU_ROLE'
+       value: 'ebs'
+  
+  _snapshot_tags_to_be_set:
+    -  key:   'NU_ROLE'
+       value: 'ebs_snapshot'
+
   _volumes_to_tag:
   # An empty list means tag all volumes
   # Example entries:
@@ -148,6 +156,10 @@ Graffiti-monkey itself can be configured using a yaml file
 :code:`_instance_tags_to_propagate` is used to define the tags that are propagated
 from an instance to its volumes. :code:`_volume_tags_to_propagate` defines the tags
 that are propagated from a volume to its snapshots.
+
+:code:`_volume_tags_to_be_set` is used to define the tags that are set on volumes
+by default. :code:`_snapshot_tags_to_be_set` defines the tags that are on snapshots
+by default.
 
 :code:`_volumes_to_tag` is used to define the volumes that are tagged. Leave empty
 to tag all volumes. :code:`_snapshots_to_tag` is used to define the snapshots to

--- a/conf/example_config.yml
+++ b/conf/example_config.yml
@@ -8,6 +8,14 @@ _volume_tags_to_propagate:
   - 'instance_id'
   - 'device'
 
+_volume_tags_to_be_set:
+  -  key:   'role'
+     value: 'ebs'
+
+_snapshot_tags_to_be_set:
+  -  key:   'role'
+     value: 'ebs_snapshot'
+
 _volumes_to_tag:
 # An empty list means tag all volumes
 # Example entries:

--- a/graffiti_monkey/__init__.py
+++ b/graffiti_monkey/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 __author__ = 'Peter Sankauskas'
-__version__ = '0.9.0'
+__version__ = '0.9.1'

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -35,6 +35,8 @@ class GraffitiMonkeyCli(object):
         self.args = None
         self.config = {"_instance_tags_to_propagate": ['Name'],
                        "_volume_tags_to_propagate": ['Name', 'instance_id', 'device'],
+                       "_volume_tags_to_be_set": [],
+                       "_snapshot_tags_to_be_set": [],
                        }
         self.dryrun = False
         self.append = False
@@ -161,6 +163,8 @@ class GraffitiMonkeyCli(object):
                                      self.profile,
                                      self.config["_instance_tags_to_propagate"],
                                      self.config["_volume_tags_to_propagate"],
+                                     self.config["_volume_tags_to_be_set"],
+                                     self.config["_snapshot_tags_to_be_set"],
                                      self.dryrun,
                                      self.append,
                                      self.volumes,

--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 class GraffitiMonkey(object):
-    def __init__(self, region, profile, instance_tags_to_propagate, volume_tags_to_propagate, dryrun, append, volumes_to_tag, snapshots_to_tag, novolumes, nosnapshots):
+    def __init__(self, region, profile, instance_tags_to_propagate, volume_tags_to_propagate, volume_tags_to_be_set, snapshot_tags_to_be_set, dryrun, append, volumes_to_tag, snapshots_to_tag, novolumes, nosnapshots):
         # This list of tags associated with an EC2 instance to propagate to
         # attached EBS volumes
         self._instance_tags_to_propagate = instance_tags_to_propagate
@@ -34,6 +34,12 @@ class GraffitiMonkey(object):
         # This is a list of tags associated with a volume to propagate to
         # a snapshot created from the volume
         self._volume_tags_to_propagate = volume_tags_to_propagate
+
+        # This is a dict of tags (keys and values) which will be set on the volumes (ebs)
+        self._volume_tags_to_be_set = volume_tags_to_be_set
+
+        # This is a dict of tags (keys and values) which will be set on the snapshots
+        self._snapshot_tags_to_be_set = snapshot_tags_to_be_set
 
         # The region to operate in
         self._region = region
@@ -193,6 +199,11 @@ class GraffitiMonkey(object):
         tags_to_set['instance_id'] = instance_id
         tags_to_set['device'] = device
 
+        # Set default tags for volume
+        for tag in self._volume_tags_to_be_set:
+            log.debug('Trying to set default tag: %s=%s', tag['key'], tag['value'])
+            tags_to_set[tag['key']] = tag['value']
+
         if self._dryrun:
             log.info('DRYRUN: Volume %s would have been tagged %s', volume.id, tags_to_set)
         else:
@@ -283,6 +294,11 @@ class GraffitiMonkey(object):
             log.debug('Trying to propagate volume tag: %s', tag_name)
             if tag_name in volume_tags:
                 tags_to_set[tag_name] = volume_tags[tag_name]
+
+        # Set default tags for snapshot
+        for tag in self._snapshot_tags_to_be_set:
+            log.debug('Trying to set default tag: %s=%s', tag['key'], tag['value'])
+            tags_to_set[tag['key']] = tag['value']
 
         if self._dryrun:
             log.info('DRYRUN: Snapshot %s would have been tagged %s', snapshot.id, tags_to_set)


### PR DESCRIPTION
With this, we can set default tags for EBS volumes and snapshots

This is useful to use different roles for ec2/volumes/snapshots