### PR TITLE
:bug: Fix for issue #17 | Windows timeformat error

### DIFF
--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -338,11 +338,11 @@ class Logging(object):
 
         # Configure our logging output
         if verbosity >= 2:
-            logging.basicConfig(level=logging.DEBUG, format=self._log_detailed_format, datefmt='%F %T')
+            logging.basicConfig(level=logging.DEBUG, format=self._log_detailed_format, datefmt='%Y-%m-%d %H:%M:%S')
         elif verbosity >= 1:
-            logging.basicConfig(level=logging.INFO, format=self._log_detailed_format, datefmt='%F %T')
+            logging.basicConfig(level=logging.INFO, format=self._log_detailed_format, datefmt='%Y-%m-%d %H:%M:%S')
         else:
-            logging.basicConfig(level=logging.INFO, format=self._log_simple_format, datefmt='%F %T')
+            logging.basicConfig(level=logging.INFO, format=self._log_simple_format, datefmt='%Y-%m-%d %H:%M:%S')
 
         # Configure Boto's logging output
         if verbosity >= 4:


### PR DESCRIPTION
%F and %T both cause errors on Windows.

Fix: Expand the format string.

Ref: 
* strftime format string %F %T consistency problem (https://bugs.python.org/issue15065)
* http://stackoverflow.com/questions/10807164/python-time-formatting-different-in-windows

Fixes #17 