### PR TITLE
Add option to filter on an instance

### DIFF
--- a/conf/example_config.yml
+++ b/conf/example_config.yml
@@ -16,6 +16,14 @@ _snapshot_tags_to_be_set:
   -  key:   'role'
      value: 'ebs_snapshot'
 
+_instance_filter:
+# Filter values with the same key (eg, tag:app) are an OR
+# Different filter keys are an AND operation (eg, tag:app and tag:team)
+# See the Filter section in http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html#API_DescribeInstances_RequestParameters
+# Example entries:
+#    'tag:app':   ['app1', 'app2']
+#    'tag:team': 'team1'
+
 _volumes_to_tag:
 # An empty list means tag all volumes
 # Example entries:

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -37,11 +37,13 @@ class GraffitiMonkeyCli(object):
                        "_volume_tags_to_propagate": ['Name', 'instance_id', 'device'],
                        "_volume_tags_to_be_set": [],
                        "_snapshot_tags_to_be_set": [],
+                       "_instance_filter": [],
                        }
         self.dryrun = False
         self.append = False
         self.volumes = None
         self.snapshots = None
+        self.instancefilter = None
         self.novolumes = False
         self.nosnapshots = False
 
@@ -152,6 +154,10 @@ class GraffitiMonkeyCli(object):
         elif "_snapshots_to_tag" in self.config.keys():
             self.snapshots = self.config["_snapshots_to_tag"]
 
+    def set_instancefilter(self):
+        if "_instance_filter" in self.config.keys():
+            self.instancefilter = self.config["_instance_filter"]
+
     def set_novolumes(self):
         self.novolumes = self.args.novolumes
 
@@ -169,6 +175,7 @@ class GraffitiMonkeyCli(object):
                                      self.append,
                                      self.volumes,
                                      self.snapshots,
+                                     self.instancefilter,
                                      self.novolumes,
                                      self.nosnapshots
                                      )
@@ -193,6 +200,7 @@ class GraffitiMonkeyCli(object):
         self.set_append()
         self.set_volumes()
         self.set_snapshots()
+        self.set_instancefilter()
         self.set_novolumes()
         self.set_nosnapshots()
 


### PR DESCRIPTION
Given a filter (see AWS documentation), retrieve instances matching that filter
and limit the selected volumes to those attached to those instances.