### PR TITLE
Adding a new --nooverwrite flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ Usage
 	  --snapshots          snapshot(s) to tag
 	  --novolumes          do not perform volume tagging
 	  --nosnapshots        do not perform snapshot tagging
+	  --nooverwrite        do not overwrite tags that are already present (goes well with --append)
 
 Examples
 --------

--- a/graffiti_monkey/cli.py
+++ b/graffiti_monkey/cli.py
@@ -41,6 +41,7 @@ class GraffitiMonkeyCli(object):
                        }
         self.dryrun = False
         self.append = False
+        self.nooverwrite = False
         self.volumes = None
         self.snapshots = None
         self.instancefilter = None
@@ -75,6 +76,8 @@ class GraffitiMonkeyCli(object):
                             help='dryrun only, display tagging actions but do not perform them')
         parser.add_argument('--append', action='store_true',
                             help='append propagated tags to existing tags (up to a total of ten tags)')
+        parser.add_argument('--nooverwrite', action='store_true',
+                            help='do not overwrite tags that are already present (goes well with --append)')
         parser.add_argument('--volumes', action='append',
                             help='volume-ids to tag')
         parser.add_argument('--snapshots', action='append',
@@ -142,6 +145,9 @@ class GraffitiMonkeyCli(object):
     def set_append(self):
         self.append = self.args.append
 
+    def set_nooverwrite(self):
+        self.nooverwrite = self.args.nooverwrite
+
     def set_volumes(self):
         if self.args.volumes:
             self.volumes = self.args.volumes
@@ -182,7 +188,8 @@ class GraffitiMonkeyCli(object):
                                      self.snapshots,
                                      self.instancefilter,
                                      self.novolumes,
-                                     self.nosnapshots
+                                     self.nosnapshots,
+                                     self.nooverwrite
                                      )
 
     def start_tags_propagation(self):

--- a/graffiti_monkey/core.py
+++ b/graffiti_monkey/core.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 
 class GraffitiMonkey(object):
-    def __init__(self, region, profile, instance_tags_to_propagate, volume_tags_to_propagate, volume_tags_to_be_set, snapshot_tags_to_be_set, dryrun, append, volumes_to_tag, snapshots_to_tag, instance_filter, novolumes, nosnapshots):
+    def __init__(self, region, profile, instance_tags_to_propagate, volume_tags_to_propagate, volume_tags_to_be_set, snapshot_tags_to_be_set, dryrun, append, volumes_to_tag, snapshots_to_tag, instance_filter, novolumes, nosnapshots, nooverwrite):
         # This list of tags associated with an EC2 instance to propagate to
         # attached EBS volumes
         self._instance_tags_to_propagate = instance_tags_to_propagate
@@ -52,6 +52,9 @@ class GraffitiMonkey(object):
 
         # If we are appending tags
         self._append = append
+
+        # If we should not overwrite any existing tags
+        self._nooverwrite = nooverwrite
 
         # Volumes we will tag
         self._volumes_to_tag = volumes_to_tag
@@ -194,6 +197,10 @@ class GraffitiMonkey(object):
 
         instance_tags = instances[instance_id].tags
 
+        if self._nooverwrite:
+            for tag_name in volume.tags:
+                del instance_tags[tag_name]
+
         tags_to_set = {}
         if self._append:
             tags_to_set = volume.tags
@@ -294,6 +301,10 @@ class GraffitiMonkey(object):
             return
 
         volume_tags = volumes[volume_id].tags
+
+        if self._nooverwrite:
+            for tag_name in snapshot.tags:
+                del volume_tags[tag_name]
 
         tags_to_set = {}
         if self._append:


### PR DESCRIPTION
With `--nooverwrite` we'll never overwrite any existing tag values. This holds for both volume tags and snapshot tags.
